### PR TITLE
re-added tile fusion feature to improve perf

### DIFF
--- a/src/Application/src/level/LevelTilemapBuilder.cpp
+++ b/src/Application/src/level/LevelTilemapBuilder.cpp
@@ -23,17 +23,16 @@ void game::TilemapBuilder::handleTileBuild(entt::registry &world, int x, int y)
     auto tile = get(x, y);
     if (tile == TileEnum::NONE) return;
 
-    glm::ivec2 size(1, 1);
+     auto size = getTileSize(x, y);
 
-    // TODO: investigate why this doesn't work. It used to work before, problem probably comes from camera (?)
-    // auto size = getTileSize(x, y);
+     for (int clearY = y; clearY < y + size.y; ++clearY) {
+        for (int clearX = x; clearX < x + size.x; ++clearX) { get(clearX, clearY) = TileEnum::NONE; }
+    }
 
-    // for (int clearY = y; clearY < y + size.y; ++clearY) {
-    //    for (int clearX = x; clearX < x + size.x; ++clearX) { get(clearX, clearY) = TileEnum::NONE; }
-    //}
-
-    glm::vec2 tilePos{static_cast<float>(x), static_cast<float>(y)};
     glm::vec2 tileSize{static_cast<float>(size.x), static_cast<float>(size.y)};
+    glm::vec2 tilePos{static_cast<float>(x), static_cast<float>(y)};
+
+    tilePos += tileSize / 2.f;
 
     switch (tile) {
     case TileEnum::FLOOR_NORMAL_ROOM: TileFactory::FloorNormalRoom(world, m_shader, tilePos, tileSize); break;

--- a/src/Application/src/level/MapGenerator.cpp
+++ b/src/Application/src/level/MapGenerator.cpp
@@ -285,7 +285,7 @@ void spawnMobsIn(
     for (auto x = r.x + 1; x < r.x + r.w - 1; ++x)
         for (auto y = r.y + 1; y < r.y + r.h - 1; ++y)
             if (randRange(0, static_cast<int>(1.0f / params.mobDensity), randomEngine) == 0)
-                game::EnemyFactory::FirstEnemy(world, shader, glm::vec2{x, y});
+                game::EnemyFactory::FirstEnemy(world, shader, glm::vec2{x + 0.5, y + 0.5});
 }
 
 auto game::generateFloor(


### PR DESCRIPTION
## Description

Merge adjacent same tiles into a bigger one. Considerably reduce number on entity on the map.

## Motivation and Context
Tremendous performance gain (not benchmarked)


## How Has This Been Tested?
We can generate over 60 dungeon per second, so 20x more than before. Every dungeon looks correct.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (anything related to the building tools or the pipeline)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (A code change that neither fixes a bug nor adds a feature)
- [ ] Style (Changes that do not affect the meaning of the code)
- [x] Perf (A code change that improves performance)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding documentation of any kind to the project)
- [ ] Other

## Checklist:
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.