### PR TITLE
fixed crash on collide spell - enemy death animation

### DIFF
--- a/src/Application/src/GameLogic/collision.cpp
+++ b/src/Application/src/GameLogic/collision.cpp
@@ -121,6 +121,8 @@ auto game::GameLogic::slots_check_collision(entt::registry &world, const engine:
         const auto &spell_pos = world.get<engine::d3::Position>(spell);
         const auto &spell_hitbox = world.get<engine::d2::HitboxFloat>(spell);
 
+        if (!world.has<engine::d2::HitboxSolid>(entity))
+            return;
         const auto &entity_pos = world.get<engine::d3::Position>(entity);
         const auto &entity_hitbox = world.get<engine::d2::HitboxSolid>(entity);
 


### PR DESCRIPTION
Fixed a crash upon collision between a spell and a dying enemy (playing the death animation)

## How Has This Been Tested?
manual

## Types of changes
- [ ] Chore (anything related to the building tools or the pipeline)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (A code change that neither fixes a bug nor adds a feature)
- [ ] Style (Changes that do not affect the meaning of the code)
- [ ] Perf (A code change that improves performance)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding documentation of any kind to the project)
- [ ] Other

## Checklist:
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
